### PR TITLE
workforce upgrades, room controller upgrade logic

### DIFF
--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -1,0 +1,20 @@
+var lib = require('lib_lib');
+
+module.exports = {
+  run: function() {
+    var room = lib.getCurrentRoom();
+    announceWorkforce(room);
+  }
+}
+
+function announceWorkforce(room) {
+  var idleCreeps = [];
+  Object.values(room.workforce.roster).forEach(roster => {
+    if (roster.length > 0) {
+      idleCreeps = idleCreeps.concat(roster);
+    }
+  });
+  if (idleCreeps.length > 0) {
+    console.log('IDLE CREEPS: ' + idleCreeps);
+  }
+}

--- a/src/controllers/build.js
+++ b/src/controllers/build.js
@@ -5,20 +5,20 @@ module.exports = {
     var currentRoom = lib.getCurrentRoom();
     var roomLevel = currentRoom.controller.level;
     calculateUpgradePriorities(currentRoom, roomLevel);
-    calculateBuildPriorities(currentRoom, roomLevel);
+    calculateConstructPriorities(currentRoom, roomLevel);
   }
 }
 
-function calculateBuildPriorities(room, roomLevel) {
+function calculateConstructPriorities(room, roomLevel) {
   switch (roomLevel) {
     case 0:
-      dispatchBuildOrders(room);
+      // dispatchConstructOrders(room);
       break;
     case 1:
-      dispatchBuildOrders(room);
+      // dispatchConstructOrders(room);
       break;
     default:
-      dispatchBuildOrders(room);
+      // dispatchConstructOrders(room);
       break;
   }
 }
@@ -26,25 +26,30 @@ function calculateBuildPriorities(room, roomLevel) {
 function calculateUpgradePriorities(room, roomLevel) {
   switch (roomLevel) {
     case 0:
-      dispatchUpgradeOrders(room);
-      break;
     case 1:
-      dispatchUpgradeOrders(room);
+      //arbitrary condition of "enough resource gathering to warrant upgrading"
+      if (room.workforce.energyTeamCount >= room.resources.energy.length) {
+        dispatchUpgradeOrders(room);
+      }
       break;
     default:
-      dispatchUpgradeOrders(room);
+      //dispatchUpgradeOrders(room);
       break;
   }
 }
 
-function dispatchBuildOrders(room) {
-  room.workforce.roster.builder.forEach(creepId => {
-    //build text goes here
+function dispatchConstructOrders(room) {
+  var roster = room.workforce.roster;
+  var buildCreeps = roster.builder ? roster.builder : roster.basic;
+  buildCreeps.forEach(creepId => {
+    Game.creeps[creepId].construct(room.controller, room.resources['energy']);
   });
 }
 
 function dispatchUpgradeOrders(room) {
-  room.workforce.roster.builder.forEach(creepId => {
+  var roster = room.workforce.roster;
+  var upgradeCreeps = roster.builder ? roster.builder : roster.basic;
+  upgradeCreeps.forEach(creepId => {
     Game.creeps[creepId].upgrade(room.controller, room.resources['energy']);
   });
 }

--- a/src/controllers/build.js
+++ b/src/controllers/build.js
@@ -4,52 +4,43 @@ module.exports = {
   run: function() {
     var currentRoom = lib.getCurrentRoom();
     var roomLevel = currentRoom.controller.level;
-    calculateUpgradePriorities(currentRoom, roomLevel);
     calculateConstructPriorities(currentRoom, roomLevel);
   }
 }
 
 function calculateConstructPriorities(room, roomLevel) {
-  switch (roomLevel) {
-    case 0:
-      // dispatchConstructOrders(room);
-      break;
-    case 1:
-      // dispatchConstructOrders(room);
-      break;
-    default:
-      // dispatchConstructOrders(room);
-      break;
-  }
-}
-
-function calculateUpgradePriorities(room, roomLevel) {
+  var roster = room.workforce.roster;
+        var upgradeCreeps = room.reinforceRosterActionGroup('builder', 'harvest', 2);
+        // console.log(upgradeCreeps);
   switch (roomLevel) {
     case 0:
     case 1:
       //arbitrary condition of "enough resource gathering to warrant upgrading"
+      if (room.workforce.energyTeamCount >= (room.resources.energy.length / 2)) {
+        dispatchUpgradeOrders(room, roster.builder);
+      }
+      break;
+    case 2:
       if (room.workforce.energyTeamCount >= room.resources.energy.length) {
-        dispatchUpgradeOrders(room);
+        var upgradeCreeps = room.reinforceRosterActionGroup('builder', 'upgrade', 2);
+        // dispatchUpgradeOrders(room, roster);
       }
       break;
     default:
-      //dispatchUpgradeOrders(room);
+      // dispatchConstructOrders(room);
       break;
   }
 }
 
-function dispatchConstructOrders(room) {
-  var roster = room.workforce.roster;
+function dispatchConstructOrders(room, roster) {
   var buildCreeps = roster.builder ? roster.builder : roster.basic;
-  buildCreeps.forEach(creepId => {
+  roster.forEach(creepId => {
     Game.creeps[creepId].construct(room.controller, room.resources['energy']);
   });
 }
 
-function dispatchUpgradeOrders(room) {
-  var roster = room.workforce.roster;
-  var upgradeCreeps = roster.builder ? roster.builder : roster.basic;
-  upgradeCreeps.forEach(creepId => {
+function dispatchUpgradeOrders(room, roster) {
+  roster.forEach(creepId => {
     Game.creeps[creepId].upgrade(room.controller, room.resources['energy']);
   });
 }

--- a/src/controllers/harvest.js
+++ b/src/controllers/harvest.js
@@ -8,9 +8,11 @@ module.exports = {
 }
 
 function dispatchResourceOrders(room) {
-  room.workforce.roster.basic.forEach(creepId => {
-    Game.creeps[creepId].farmAndTransport(room.resources['energy']);
-  });
+  if (room.workforce.energyTeamCount <= room.resources.energy.length) {
+    room.workforce.roster.builder.forEach(creepId => {
+        Game.creeps[creepId].farmAndTransport(room.resources['energy']);
+    });
+  }
   room.workforce.roster.energyHarvester.forEach(creepId => {
     Game.creeps[creepId].farm(room.resources['energy']);
   });

--- a/src/controllers/harvest.js
+++ b/src/controllers/harvest.js
@@ -1,22 +1,30 @@
 var lib = require('lib_lib');
+var workforceLib = require('lib_workforce_lib');
 
 module.exports = {
   run: function() {
     var currentRoom = lib.getCurrentRoom();
-    dispatchResourceOrders(currentRoom);
+    calculatePriorities(currentRoom);
   }
 }
 
-function dispatchResourceOrders(room) {
-  if (room.workforce.energyTeamCount <= room.resources.energy.length) {
-    room.workforce.roster.builder.forEach(creepId => {
-        Game.creeps[creepId].farmAndTransport(room.resources['energy']);
-    });
-  }
-  room.workforce.roster.energyHarvester.forEach(creepId => {
+function calculatePriorities(room) {
+  var harvesters = room.workforce.roster.energyHarvester;
+  dispatchHarvestOrders(harvesters, room, 'energyHarvester');
+  var transporters = room.workforce.roster.transporter;
+  dispatchHarvestOrders(transporters, room, 'transporter');
+}
+
+function dispatchHarvestOrders(team, room, roster) {
+  team.forEach(creepId => {
     Game.creeps[creepId].farm(room.resources['energy']);
   });
-  room.workforce.roster.transporter.forEach(creepId => {
+  workforceLib.removeFromRoster(room, roster, team);
+}
+
+function dispatchTransportOrders(team, room, roster) {
+  team.forEach(creepId => {
     Game.creeps[creepId].transport(room.resources['dropped']);
   });
+  workforceLib.removeFromRoster(room, roster, team);
 }

--- a/src/controllers/manufacture.js
+++ b/src/controllers/manufacture.js
@@ -3,45 +3,27 @@ var creepLib = require('lib_creep_lib');
 
 module.exports = {
   run: function() {
-    var currentRoom = lib.getCurrentRoom();
-    var roster = currentRoom.workforce.roster;
     var spawn = lib.getSpawn();
-    var role = chooseRoleType(currentRoom, roster, spawn);
-    if (role) {
+    var room = lib.getCurrentRoom();
+    var role = chooseRoleType(room, spawn);
+    var canBuild = spawn.canBuildCreep(role);
+    if (canBuild === 0) {
       spawn.buildCreep(role);
     }
   }
 }
 
-function chooseRoleType(currentRoom, roster, spawn) {
-  //build roster counts for comparisons
-  var [claimers, energyHarvesters, transporters, basics, builders, others] = [0, 0, 0, 0, 0, 0];
-  for (let role in roster) {
-    switch (role) {
-      case 'basic':
-        basics = (roster[role]) ? roster[role].length : 0;
-        break;
-      case 'claimer':
-        claimers = (roster[role]) ? roster[role].length : 0;
-        break
-      case 'energyHarvester':
-        energyHarvesters = (roster[role]) ? roster[role].length : 0;
-        break;
-      case 'transporter':
-        transporters = (roster[role]) ? roster[role].length : 0;
-        break;
-      case 'builder':
-        builders = (roster[role]) ? roster[role].length : 0;
-        break;
-      default:
-        others = (roster[role]) ? roster[role].length : 0;
-        break;
-    }
-  }
-  if (currentRoom.workforce.creepCount < 2) {
-    return 'basic';
-  }
-  if (currentRoom.workforce.energyTeamCount < (currentRoom.workforce.creepCount / 3)) {
+function chooseRoleType(room, spawn) {
+  var roster = room.workforce.roster;
+  var creepCount = room.workforce.creepCount;
+  //sets better roster variables
+  var basics = (roster.basic) ? roster.basic.length : 0;
+  var claimers = (roster.claimer) ? roster.claimer.length : 0;
+  var energyHarvesters = (roster.energyHarvester) ? roster.energyHarvester.length : 0;
+  var transporters = (roster.transporter) ? roster.transporter.length : 0;
+  var builders = (roster.builder) ? roster.builder.length : 0;
+
+  if (room.workforce.energyTeamCount < (creepCount / 2)) {
     if (energyHarvesters > transporters) {
       return 'transporter';
     } else {

--- a/src/controllers/manufacture.js
+++ b/src/controllers/manufacture.js
@@ -38,14 +38,15 @@ function chooseRoleType(currentRoom, roster, spawn) {
         break;
     }
   }
-  if (currentRoom.workforce.creepCount > 3) {
-    if (builders === 0) {
-      return 'builder';
+  if (currentRoom.workforce.creepCount < 2) {
+    return 'basic';
+  }
+  if (currentRoom.workforce.energyTeamCount < (currentRoom.workforce.creepCount / 3)) {
+    if (energyHarvesters > transporters) {
+      return 'transporter';
+    } else {
+      return 'energyHarvester';
     }
   }
-  if (energyHarvesters > transporters) {
-    return 'transporter';
-  } else {
-    return 'energyHarvester';
-  }
+  return 'builder';
 }

--- a/src/lib/creep_lib.js
+++ b/src/lib/creep_lib.js
@@ -1,24 +1,24 @@
 module.exports = {
-  getCreepRoleAbilities: function(role) {
-    var abilities = [];
+  getCreepRoleParts: function(role) {
+    var parts = [];
     switch (role) {
       case 'builder':
-        abilities = [WORK, CARRY, CARRY, MOVE, MOVE];
+        parts = [WORK, CARRY, CARRY, MOVE, MOVE];
         break;
       case 'energyHarvester':
-        abilities = [WORK, WORK, MOVE];
+        parts = [WORK, WORK, MOVE];
         break;
       case 'transporter':
-        abilities = [CARRY, CARRY, CARRY, MOVE, MOVE];
+        parts = [CARRY, CARRY, CARRY, MOVE, MOVE];
         break;
       case 'claimer':
-        abilities = [CLAIM, CARRY, WORK, MOVE];
+        parts = [CLAIM, CARRY, WORK, MOVE];
         break;
       case 'basic':
       default:
-        abilities = [CARRY, WORK, MOVE];
+        parts = [WORK, CARRY, MOVE];
         break;
     }
-    return abilities;
+    return parts;
   },
 }

--- a/src/lib/creep_lib.js
+++ b/src/lib/creep_lib.js
@@ -3,7 +3,7 @@ module.exports = {
     var abilities = [];
     switch (role) {
       case 'builder':
-        abilities = [WORK, CARRY, CARRY, MOVE];
+        abilities = [WORK, CARRY, CARRY, MOVE, MOVE];
         break;
       case 'energyHarvester':
         abilities = [WORK, WORK, MOVE];

--- a/src/lib/lib.js
+++ b/src/lib/lib.js
@@ -2,18 +2,20 @@ module.exports = {
   generateId: function(role = '') {
     return role + Game.time + '_' + Math.floor(Math.random() * 1000000);
   },
-
   //works with just one room, need to add multi-room functionality
   getCurrentRoom: function() {
     for (var name in Game.rooms) {
       return Game.rooms[name];
     }
   },
-
   //works with just spawn, need to add multi-spawn functionality
   getSpawn: function() {
     for (var name in Game.spawns) {
       return Game.spawns[name];
     }
+  },
+  //checks if object is empty or not
+  isEmpty: function(obj) {
+    return (Object.keys(obj).length === 0);
   }
 }

--- a/src/lib/workforce_lib.js
+++ b/src/lib/workforce_lib.js
@@ -1,0 +1,9 @@
+module.exports = {
+  removeFromRoster: function(room, roster, creeps) {
+    var purgedRoster = room.workforce.roster[roster].filter(creepKey => {
+      return creeps.indexOf(creepKey) < 0;
+    });
+    room.workforce.roster[roster] = (purgedRoster.length > 0) ? purgedRoster : [];
+    room.workforce.dispatched[roster] = room.workforce.dispatched[roster].concat(creeps);
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ var setup = require('setup');
 var harvest = require('controllers_harvest');
 var manufacture = require('controllers_manufacture');
 var build = require('controllers_build');
+var cleanup = require('cleanup');
 
 module.exports.loop = function() {
   setup.runConstructors();
@@ -9,4 +10,5 @@ module.exports.loop = function() {
   harvest.run();
   manufacture.run();
   build.run();
+  cleanup.run();
 }

--- a/src/models/creep.js
+++ b/src/models/creep.js
@@ -29,6 +29,10 @@ function addMethods() {
     }
   };
   Creep.prototype.goDo = function(target, command, action, args = { path: 'movePath' }) {
+      if (!target) {
+        console.log(`ERROR: Null target for creep ${this.name} attempting ${command}: ${action}`);
+        return;
+      }
       switch (command) {
         case 'harvest':
           var attempt = this.harvest(target);

--- a/src/models/creep.js
+++ b/src/models/creep.js
@@ -45,7 +45,7 @@ function addMethods() {
           var attempt = ERR_NOT_IN_RANGE;
           break;
       }
-      target.freeSpaces -= 1;
+      target.freeSpaces = target.freeSpaces - 1;
       this.memory.action = action;
       if (attempt == ERR_NOT_IN_RANGE) {
         this.moveTo(target, {visualizePathStyle: {stroke: config.styling[args.path].stroke}});

--- a/src/models/creep.js
+++ b/src/models/creep.js
@@ -7,6 +7,9 @@ module.exports = {
 }
 
 function addMethods() {
+  Creep.prototype.construct = function(target) {
+
+  };
   Creep.prototype.farm = function(resourceNodes) {
     var target = this.getMemoryObject('target');
     if (!target) {

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1,5 +1,6 @@
 module.exports = {
   extendRoom: function() {
+    addMethods();
     Object.defineProperty(Room, 'workforce', {
       get() { return this._workforce; },
       set(newValue) { this._workforce = newValue; },
@@ -13,4 +14,16 @@ module.exports = {
       configurable: true,
     });
   }
+}
+
+function addMethods() {
+  Room.prototype.reinforceRosterActionGroup = function(role, action, count) {
+    var actionGroup = this.workforce.roster[role].filter(creepKey => {
+      var creep = Game.creeps[creepKey];
+      if (creep.memory.action === action) {
+        return true;
+      }
+    });
+    return actionGroup;
+  };
 }

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -17,7 +17,7 @@ module.exports = {
 }
 
 function addMethods() {
-  Room.prototype.reinforceRosterActionGroup = function(role, action, count) {
+  Room.prototype.getRosterActionGroup = function(role, action) {
     var actionGroup = this.workforce.roster[role].filter(creepKey => {
       var creep = Game.creeps[creepKey];
       if (creep.memory.action === action) {
@@ -26,4 +26,30 @@ function addMethods() {
     });
     return actionGroup;
   };
+  Room.prototype.reinforceRosterActionGroup = function(role, action, count, conscriptAction) {
+    //come up with better method of determining which farming builder should be assigned to which task
+    var actionGroup = this.getRosterActionGroup(role, action);
+    var conscriptGroup = this.getRosterActionGroup(role, conscriptAction)
+    var creepDiff = count - actionGroup.length;
+    if (creepDiff > 0 && conscriptGroup.length > 0) {
+      var conscripts = selectBestConscript(conscriptGroup, conscriptAction, creepDiff);
+      return actionGroup.concat(conscripts);
+    }
+    return actionGroup;
+  };
+}
+
+function selectBestConscript(group, action, count) {
+  if (count >= group.length) {
+    return group;
+  }
+  var sortedGroup = group.sort((a,b) => {
+    switch (action) {
+      case 'harvest':
+      default:
+        return Game.creeps[a].store.getFreeCapacity() < Game.creeps[b].store.getFreeCapacity();
+        break;
+    }
+  });
+  return sortedGroup.slice(0, count);
 }

--- a/src/models/structureSpawn.js
+++ b/src/models/structureSpawn.js
@@ -3,15 +3,20 @@ var creepLib = require('lib_creep_lib');
 
 module.exports = {
   extendStructureSpawn: function() {
-    StructureSpawn.prototype.buildCreep = function(role) {
-      var abilities = creepLib.getCreepRoleAbilities(role);
+    StructureSpawn.prototype.buildCreep = function(role, traits = {}) {
+      var parts = creepLib.getCreepRoleParts(role);
       var creepId = lib.generateId(role);
-      var traits = {
-        memory: {
+      if (traits.memory === undefined || lib.isEmpty(traits.memory)) {
+        traits.memory = {
           role: role
-        }
-      };
-      this.spawnCreep(abilities, creepId, traits);
-    }
+        };
+      } else {
+        traits.memory.role = role;
+      }
+      return this.spawnCreep(parts, creepId, traits);
+    };
+    StructureSpawn.prototype.canBuildCreep = function(role) {
+      return this.buildCreep(role, { dryRun: true });
+    };
   }
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -41,6 +41,13 @@ function buildRoom() {
             transporter: [],
             builder: [],
         },
+        dispatched: {
+            basic: [],
+            claimer: [],
+            energyHarvester: [],
+            transporter: [],
+            builder: [],
+        },
         actionCount: {},
         creepCount: 0
     };

--- a/src/setup.js
+++ b/src/setup.js
@@ -53,5 +53,6 @@ function buildRoom() {
       }
       creepCount += 1;
     }
+    currentRoom.workforce.energyTeamCount = currentRoom.workforce.roster.energyHarvester.length + currentRoom.workforce.roster.transporter.length;
     currentRoom.workforce.creepCount = creepCount;
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -41,15 +41,23 @@ function buildRoom() {
             transporter: [],
             builder: [],
         },
+        actionCount: {},
         creepCount: 0
     };
     let creepCount = 0;
     for (var creepKey in Game.creeps) {
-      var role = Game.creeps[creepKey].memory.role;
+      var creep = Game.creeps[creepKey];
+      var role = creep.memory.role;
       if (currentRoom.workforce.roster[role] === undefined) {
         currentRoom.workforce.roster[role] = [creepKey];
       } else {
         currentRoom.workforce.roster[role].push(creepKey);        
+      }
+      var action = creep.memory.action;
+      if (currentRoom.workforce.actionCount[action]) {
+        currentRoom.workforce.actionCount[action] += 1;
+      } else {
+        currentRoom.workforce.actionCount[action] = 1;
       }
       creepCount += 1;
     }


### PR DESCRIPTION
* adds cleanup script to run checks for post-action state of game
* further builds out workforce with roster/dispatch groups to represent assigned/unassigned creeps
* adds "teams" to workforce rosters, teams are subgroups of a roster given a specific command. initial implementation is to subdivide builder roster into builder and upgrader teams
* creep role logic improved
* adds room controller upgrade logic and groundwork code to add building construction logic